### PR TITLE
4-2 マイグレーション関連

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,9 +12,13 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました"
+    @task = Task.new(task_params)
+
+    if @task.save
+      redirect_to tasks_url, notice: "タスク「#{@task.name}」を登録しました"
+    else
+      render :new
+    end
   end
 
   def edit

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,3 @@
 class Task < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,9 +1,15 @@
 class Task < ApplicationRecord
+  before_validation :set_nameless_name
   validates :name, presence: true, length: { maximum: 30 }
   validate :validate_name_not_including_comma
+
 
   private
   def validate_name_not_including_comma
     errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
+
+  def set_nameless_name
+    self.name = '名前なし' if name.blank?
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,9 @@
 class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
+  validate :validate_name_not_including_comma
+
+  private
+  def validate_name_not_including_comma
+    errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
 end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,3 +1,9 @@
+- if task.errors.present?
+  ul#error_explanation
+    - task.errors.full_messages.each do |message|
+      li = message
+
+
 = form_with model: task, local: true do |f|
   .form-group
     = f.label :name

--- a/db/migrate/20220511082006_change_tasks_name_not_null.rb
+++ b/db/migrate/20220511082006_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :tasks, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_11_051200) do
+ActiveRecord::Schema.define(version: 2022_05_11_082006) do
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 概要
マイグレーション関連の更新など

## やったこと
- nameに対してNOT NULL制約を追加
- 文字カラムの長さ制限(30文字)
- バリデーションの設定(name)
- コントローラーの修正(バリデーションエラーのときの動作)
- 登録、編集にてエラーとなったときのメッセージ表示
- オリジナルエラー検証記述(nameにカンマを含まないようにする)
- コールバック実装(名前無記入の場合に'名前なし'で自動で表記される)